### PR TITLE
if the body is null, the reader doesn't exist.

### DIFF
--- a/vcf.js
+++ b/vcf.js
@@ -957,7 +957,6 @@ vcf.fileSize=async(url='https://ftp.ncbi.nih.gov/snp/organisms/human_9606/VCF/00
     let response = await fetch(url,{
         method:'HEAD'
     });
-    const reader = response.body.getReader();
     const contentLength = response.headers.get('Content-Length');
     return parseInt(contentLength)
 }


### PR DESCRIPTION
Issue #3 : Firefox is returning a response with a null body.  Since we are just checking the file size, there is no reason to get a reader from a null body. 

now works in Firefox 124.

size = await vcf.fileSize('https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz')
102587895 